### PR TITLE
force iptables-persistent to be non-interactive

### DIFF
--- a/openvpn.json
+++ b/openvpn.json
@@ -93,6 +93,8 @@
         "sudo systemctl start rng-tools.service",
         "echo === OpenVPN ===",
         "sudo apt-get -qq update",
+        "echo iptables-persistent iptables-persistent/autosave_v4 boolean true | sudo debconf-set-selections",
+        "echo iptables-persistent iptables-persistent/autosave_v6 boolean true | sudo debconf-set-selections",
         "sudo apt-get -y -qq install --no-install-recommends openvpn openssl iptables iptables-persistent netfilter-persistent",
         "sudo apt-get autoclean",
         "sudo apt-get clean",


### PR DESCRIPTION
Hello!  iptables-persistent package hangs on an interactive request if not expressly disabled.  This will force the package to auto-save.